### PR TITLE
Load configuration files with aliases on Psych > 4.0

### DIFF
--- a/econfig.gemspec
+++ b/econfig.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = ">= 2.0"
+  gem.required_ruby_version = ">= 2.7"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"

--- a/lib/econfig/version.rb
+++ b/lib/econfig/version.rb
@@ -1,3 +1,3 @@
 module Econfig
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/lib/econfig/yaml.rb
+++ b/lib/econfig/yaml.rb
@@ -33,10 +33,18 @@ module Econfig
 
       @mutex.synchronize do
         @options ||= if File.exist?(path)
-          ::YAML.load(::ERB.new(File.read(path)).result)[Econfig.env] || {}
+          load_yaml(::ERB.new(File.read(path)).result)[Econfig.env] || {}
         else
           {}
         end
+      end
+    end
+
+    def load_yaml(src)
+      if Psych::VERSION > "4.0"
+        ::YAML.safe_load(src, permitted_classes: [Symbol], aliases: true)
+      else
+        ::YAML.load(src)
       end
     end
   end


### PR DESCRIPTION
### What is the goal?

Allow applications using Ruby 3.2.0 to use `econfig` with yml files containing `aliases`